### PR TITLE
Fix 15

### DIFF
--- a/src/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/src/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -62,9 +62,8 @@ namespace TestHelper
       foreach (var project in projects)
       {
         var compilation = project.GetCompilationAsync().Result;
-        var driver = AnalyzerDriver.Create(compilation, ImmutableArray.Create(analyzer), null, out compilation, CancellationToken.None);
-        var discarded = compilation.GetDiagnostics();
-        var diags = driver.GetDiagnosticsAsync().Result;
+        var compilationWithAnalyzers = compilation.WithAnalyzers(ImmutableArray.Create(analyzer), null, CancellationToken.None);
+        var diags = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().Result;
         foreach (var diag in diags)
         {
           if (diag.Location == Location.None || diag.Location.IsInMetadata)
@@ -157,7 +156,7 @@ namespace TestHelper
 
       var projectId = ProjectId.CreateNewId(debugName: TestProjectName);
 
-      var solution = new CustomWorkspace()
+      var solution = new AdhocWorkspace()
           .CurrentSolution
           .AddProject(projectId, TestProjectName, TestProjectName, language)
           .AddMetadataReference(projectId, CorlibReference)

--- a/src/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer.Test/UnitTests.cs
+++ b/src/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer.Test/UnitTests.cs
@@ -77,7 +77,7 @@ namespace ConsoleApplication1
 		{
 			string selection = ""id, name, title"";
             string where = ""id = '1'"";
-            var cmd = new SqlCommand(""SEL \{selection} FROM myTable WHERE \{where}"");
+            var cmd = new SqlCommand($""SEL {selection} FROM myTable WHERE {where}"");
         }
 	}
 }";

--- a/src/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer.Test/Verifiers/CodeFixVerifier.cs
+++ b/src/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer.Test/Verifiers/CodeFixVerifier.cs
@@ -82,7 +82,7 @@ namespace TestHelper
       {
         var actions = new List<CodeAction>();
         var context = new CodeFixContext(document, analyzerDiagnostics[0], (a, d) => actions.Add(a), CancellationToken.None);
-        codeFixProvider.ComputeFixesAsync(context).Wait();
+        codeFixProvider.RegisterCodeFixesAsync(context).Wait();
 
         if (!actions.Any())
         {

--- a/src/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer/Diagnostics/Helper.cs
+++ b/src/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer/Diagnostics/Helper.cs
@@ -14,8 +14,7 @@ namespace TSqlAnalyzer.Diagnostics
         {
             string sql = string.Empty;
 
-            if (id.Contains("\\{"))
-                id = id.Replace("\\{", " + {").Replace("}", "} + ");
+            id = id.Replace("{", " + {").Replace("}", "} + ");
 
             string[] list = id.Split('+');
 
@@ -23,7 +22,7 @@ namespace TSqlAnalyzer.Diagnostics
             {
                 if (s.Contains("{") == false)
                 {
-                    sql += s.Replace("\"", string.Empty);
+                    sql += s.Replace("$\"", string.Empty).Replace("\"", string.Empty);
                 }
                 else
                 {

--- a/src/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer.csproj
+++ b/src/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer.csproj
@@ -88,8 +88,9 @@
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom">
-      <HintPath>..\..\packages\Microsoft.SqlServer.TransactSql.ScriptDom.12.0.2000.8\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom, Version=12.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.SqlServer.TransactSql.ScriptDom.12.0.1\lib\net40\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer.csproj
+++ b/src/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer.csproj
@@ -10,9 +10,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TSqlAnalyzer</RootNamespace>
     <AssemblyName>TSqlAnalyzer</AssemblyName>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile44</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -57,24 +57,41 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-rc1\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-rc1\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Desktop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.CSharp.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-rc1\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Desktop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-rc1\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom">
       <HintPath>..\..\packages\Microsoft.SqlServer.TransactSql.ScriptDom.12.0.2000.8\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
     </Reference>
+    <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
@@ -108,7 +125,7 @@
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc1\tools\analyzers\C#\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc1\tools\analyzers\Microsoft.CodeAnalysis.Analyzers.dll" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>"$(SolutionDir)\packages\NuGet.CommandLine.2.8.3\tools\NuGet.exe" pack TSqlAnalyzer.nuspec -OutputDirectory .</PostBuildEvent>
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>

--- a/src/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer/packages.config
+++ b/src/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0-rc1" targetFramework="portable46-net451+win81" userInstalled="true" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-rc1" targetFramework="portable46-net451+win81" userInstalled="true" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0-rc1" targetFramework="portable46-net451+win81" userInstalled="true" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-rc1" targetFramework="portable46-net451+win81" userInstalled="true" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-rc1" targetFramework="portable46-net451+win81" userInstalled="true" />
-  <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable46-net451+win81" userInstalled="true" />
-  <package id="NuGet.CommandLine" version="2.8.3" targetFramework="portable46-net451+win81" userInstalled="true" />
-  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="portable46-net451+win81" userInstalled="true" />
-  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="portable46-net451+win81" userInstalled="true" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0-rc1" targetFramework="net451" userInstalled="true" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-rc1" targetFramework="net451" userInstalled="true" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0-rc1" targetFramework="net451" userInstalled="true" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-rc1" targetFramework="net451" userInstalled="true" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-rc1" targetFramework="net451" userInstalled="true" />
+  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net451" userInstalled="true" />
+  <package id="NuGet.CommandLine" version="2.8.3" targetFramework="net451" userInstalled="true" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net451" userInstalled="true" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net451" userInstalled="true" />
 </packages>

--- a/src/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer/packages.config
+++ b/src/TSqlAnalyzer/TSqlAnalyzer/TSqlAnalyzer/packages.config
@@ -6,6 +6,7 @@
   <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-rc1" targetFramework="net451" userInstalled="true" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-rc1" targetFramework="net451" userInstalled="true" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net451" userInstalled="true" />
+  <package id="Microsoft.SqlServer.TransactSql.ScriptDom" version="12.0.1" targetFramework="net451" userInstalled="true" />
   <package id="NuGet.CommandLine" version="2.8.3" targetFramework="net451" userInstalled="true" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net451" userInstalled="true" />
   <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net451" userInstalled="true" />


### PR DESCRIPTION
* Install `Microsoft.SqlServer.TransactSql.ScriptDom` as a proper NuGet dependency (previously the project wouldn't build when you simply clone the source code)
* Update the test framework to support CTP 6 (Roslyn RC 1). This is the minimal set of changes required for basic support. Fixes #15.
* Update `Helper.BuildSqlStringFromIdString` to provide a minimal level of support for the new string interpolation syntax. The tests for this functionality now pass, but I would recommend updating the code to work directly with the parse tree representation of an interpolated string rather than rely on `string.Replace`.